### PR TITLE
Add handling of exceptions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
   - Added a new option `old_results` that—if set to True—will preserve such lines.
 - Fixed a bug that caused intentional blank lines to be removed. ([#7](https://github.com/jayqi/reprexlite/pull/7))
 - Added stdout capturing. Any content printed to stdout will be shown as a result in the reprex. ([#10](https://github.com/jayqi/reprexlite/pull/10))
+- Added exception handling and stacktrace capture. If the input code has an exception, the stacktrace will be shown as a result in the reprex. ([#12](https://github.com/jayqi/reprexlite/pull/12))
 
 ## v0.1.0 (2021-02-15)
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -150,7 +150,7 @@ cases = [
 
         sqrt("four")
         #> Traceback (most recent call last):
-        #>   File "{REPO_ROOT}/reprexlite/code.py", line 70, in evaluate
+        #>   File "{REPO_ROOT / "reprexlite" / "code.py"}", line 70, in evaluate
         #>     result = eval(str(self).strip(), scope, scope)
         #>   File "<string>", line 1, in <module>
         #>   File "<string>", line 2, in sqrt

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,9 +1,13 @@
 from collections import namedtuple
+from pathlib import Path
 from textwrap import dedent
-from reprexlite.code import CodeBlock
 
 import pytest
 
+from reprexlite.code import CodeBlock
+
+
+REPO_ROOT = Path(__file__).parents[1].resolve()
 
 Case = namedtuple("Case", ["input", "expected"])
 
@@ -112,6 +116,45 @@ cases = [
         #> start: 1, end: 5
         [x + 1 for x in arr]
         #> [2, 3, 4, 5, 6]
+        """,
+    ),
+    Case(
+        """\
+        def return_none():
+            return None
+
+        return_none()
+        """,
+        """\
+        def return_none():
+            return None
+
+        return_none()
+        #> None
+        """,
+    ),
+    Case(
+        """\
+        import math
+
+        def sqrt(x):
+            return math.sqrt(x)
+
+        sqrt("four")
+        """,
+        f"""\
+        import math
+
+        def sqrt(x):
+            return math.sqrt(x)
+
+        sqrt("four")
+        #> Traceback (most recent call last):
+        #>   File "{REPO_ROOT}/reprexlite/code.py", line 70, in evaluate
+        #>     result = eval(str(self).strip(), scope, scope)
+        #>   File "<string>", line 1, in <module>
+        #>   File "<string>", line 2, in sqrt
+        #> TypeError: must be real number, not str
         """,
     ),
 ]


### PR DESCRIPTION
Example:

```python
import math

def sqrt(x):
    return math.sqrt(x)

sqrt("four")
#> Traceback (most recent call last):
#>   File "/Users/jqi/repos/reprexlite/reprexlite/code.py", line 70, in evaluate
#>     result = eval(str(self).strip(), scope, scope)
#>   File "<string>", line 1, in <module>
#>   File "<string>", line 2, in sqrt
#> TypeError: must be real number, not str
```

Closes #11