### PR TITLE
Fix missing importlib_metadata for Python 3.6, 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,9 +50,16 @@ jobs:
         shell: bash
         run: |
           make dist
-          python -m pip install dist/reprexlite-*.whl --no-deps --force-reinstall
-          python -m pip install dist/reprexlite-*.tar.gz --no-deps --force-reinstall
+          python -m venv .venv-whl
+          source .venv-whl/bin/activate
+          python -m pip install dist/reprexlite-*.whl
           reprex --version
+          deactivate
+          python -m venv .venv-sdist
+          source .venv-sdist/bin/activate
+          python -m pip install dist/reprexlite-*.tar.gz
+          reprex --version
+          deactivate
 
       - name: Test building documentation
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,13 +50,29 @@ jobs:
         shell: bash
         run: |
           make dist
+
+          echo "=== Testing wheel installation ==="
           python -m venv .venv-whl
-          source .venv-whl/bin/activate
+          if [[ -f .venv-whl/bin/activate ]]; then
+            # Unix
+            source .venv-whl/bin/activate
+          else
+            # Windows
+            . .venv-whl/Scripts/activate
+          fi
           python -m pip install dist/reprexlite-*.whl
           reprex --version
           deactivate
+
+          echo "=== Testing source installation ==="
           python -m venv .venv-sdist
-          source .venv-sdist/bin/activate
+          if [[ -f .venv-sdist/bin/activate ]]; then
+            # Unix
+            source .venv-sdist/bin/activate
+          else
+            # Windows
+            . .venv-whl/Scripts/activate
+          fi
           python -m pip install dist/reprexlite-*.tar.gz
           reprex --version
           deactivate

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,8 @@
 ## v0.4.2 (2021-02-28)
 
 - Added support for parsing code copied from an interactive Python shell (REPL) with `>>>` prompts. ([#29](https://github.com/jayqi/reprexlite/pull/29))
-- Fixed issue where `tests` module was unintentionally included in distribution ([#30](https://github.com/jayqi/reprexlite/pull/30)).
+- Fixed issue where `tests` module was unintentionally included in distribution. ([#30](https://github.com/jayqi/reprexlite/pull/30))
+- Fixed missing requirement `importlib_metadata` for Python 3.6 and 3.7. ([#31](https://github.com/jayqi/reprexlite/pull/31))
 
 ## v0.4.1 (2021-02-27)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+importlib_metadata ; python_version < "3.8"
 libcst
 typer
 


### PR DESCRIPTION
Test distribution installation in virtual environments. 