### PR TITLE
Better handling of syntax errors

### DIFF
--- a/reprexlite/cli.py
+++ b/reprexlite/cli.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 
 from reprexlite.config import ParsingMethod, ReprexConfig
-from reprexlite.exceptions import IPythonNotFoundError
+from reprexlite.exceptions import InputSyntaxError, IPythonNotFoundError
 from reprexlite.formatting import formatter_registry
 from reprexlite.reprexes import Reprex
 from reprexlite.version import __version__
@@ -163,7 +163,12 @@ def main(
     if verbose:
         typer.echo(config)
 
-    r = Reprex.from_input(input=input, config=config)
+    try:
+        r = Reprex.from_input(input=input, config=config)
+    except InputSyntaxError as e:
+        print("ERROR: reprexlite has encountered an error while evaluating your input.")
+        print(e)
+        raise typer.Exit(1) from e
 
     if outfile:
         with outfile.open("w") as fp:

--- a/reprexlite/exceptions.py
+++ b/reprexlite/exceptions.py
@@ -6,6 +6,10 @@ class BlackNotFoundError(ModuleNotFoundError, ReprexliteException):
     """Raised when ipython cannot be found when using a black-dependent feature."""
 
 
+class InputSyntaxError(SyntaxError, ReprexliteException):
+    """Raised when encountering a syntax error when parsing input."""
+
+
 class InvalidInputPrefixesError(ValueError, ReprexliteException):
     pass
 
@@ -26,16 +30,16 @@ class MissingDependencyError(ImportError, ReprexliteException):
     pass
 
 
-class PromptLengthMismatchError(ReprexliteException):
-    pass
-
-
 class NoPrefixMatchError(ValueError, ReprexliteException):
     pass
 
 
 class NotAFormatterError(TypeError, ReprexliteException):
     """Raised when registering a formatter that is not a subclass of the Formatter base class."""
+
+
+class PromptLengthMismatchError(ReprexliteException):
+    pass
 
 
 class PygmentsNotFoundError(ModuleNotFoundError, ReprexliteException):

--- a/reprexlite/ipython.py
+++ b/reprexlite/ipython.py
@@ -57,11 +57,7 @@ class ReprexMagics(Magics):
         # Cell magic, render reprex
         with patch_edit(cell):
             result = runner.invoke(reprexlite.cli.app, line.split())
-            if result.exit_code == 0:
-                print(result.stdout, end="")
-            else:
-                print("ERROR: reprexlite has encountered an error while evaluating your input.")
-                print(result.exception, end="")
+            print(result.stdout, end="")
 
 
 def load_ipython_extension(ipython: InteractiveShell):


### PR DESCRIPTION
- Adds `InputSyntaxError` exception class
- Capture full traceback if libcst has a parser error and raise as `InputSyntaxError`. 
- For user interfaces (CLI, IPython shell, IPython magic), don't print traceback, just print error message of the syntax error. Traceback is not that useful for debugging, since it's just internals of reprexlite and libcst. 