### PR TITLE
GitHub Actions maintenance

### DIFF
--- a/.github/workflows/docs-main.yml
+++ b/.github/workflows/docs-main.yml
@@ -10,12 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,16 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,16 @@ jobs:
     name: Code Quality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |
@@ -41,12 +45,16 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |
@@ -87,13 +95,13 @@ jobs:
       - name: Test building documentation
         run: |
           make docs
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
 
       - name: Deploy site preview to Netlify
         if: |
-          matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+          matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
           && github.event.pull_request != null
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v2.0.0
         with:
           publish-dir: "./docs/site"
           production-deploy: false


### PR DESCRIPTION
- Bump actions to versions that use node16 as node12 ones are deprecated
- Add caching to `actions/setup-python`
- Bump Python version used for non-matrixed steps to 3.10